### PR TITLE
ci: pin PredictiveEcology/actions to @main

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
+      - uses: PredictiveEcology/actions/install-spatial-deps@main
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
+      - uses: PredictiveEcology/actions/install-spatial-deps@main
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
Tags do not move, so a pinned tag freezes this repo on whatever the action looked like when that tag was cut.

`v0.1` and `v0.2` both predate the removal of the **ubuntugis-unstable PPA**, which installs libgdal37 while Posit's noble binaries are built against libgdal34 — an ABI mismatch that surfaces only at lazy-load, as `libgdal.so.34: cannot open shared object file`.

`@main` is the org standard: consumers pick up fixes without a pin bump, and `PredictiveEcology/actions` now has its own self-test CI gating what lands there (PredictiveEcology/actions#24).

**Expect the first Ubuntu run to be slow, and possibly red once.** Any cached R library built while the PPA was active contains a `terra.so` linked against `libgdal.so.37`, which no longer exists. I have already cleared this repo's Ubuntu caches where any existed; if a leg still fails with a missing `libgdal.so.37`, clear the Ubuntu caches and re-run — it is the one-time transition, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DVjmY3im9Xak7tXLSMGCa