### PR TITLE
ci: migrate R-CMD-check to the org reusable workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,62 +1,24 @@
-on:
-  push:
-    branches:
-      - main
-      - master
-      - development
-      - LandWeb
-  pull_request:
-    branches:
-      - main
-      - master
-      - development
+## Thin caller -- the matrix, system dependencies, caching, Drive staging
+## and the check itself all live in PredictiveEcology/actions. This file only
+## says which package to check and what it needs on top of the org defaults.
+##
+## Pinned @main deliberately: tags freeze and rot (v0.1/v0.2 kept the
+## ubuntugis PPA for months after the workflows rejected it). The actions repo
+## gates merges with its own self-test CI.
 
 name: R-CMD-check
 
+on:
+  push:
+    branches: [main, master, development, LandWeb]
+  pull_request:
+    branches: [main, master, development, LandWeb]
+
 jobs:
   R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }}, nosuggests ${{ matrix.config.nosuggests }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: macOS-latest,    nosuggests: false, r: 'release'}
-          - {os: windows-latest,  nosuggests: false, r: 'devel'}
-          - {os: windows-latest,  nosuggests: false, r: 'release'}
-          - {os: windows-latest,  nosuggests: false, r: 'oldrel-1'}
-          - {os: windows-latest,  nosuggests: false, r: 'oldrel-2'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'devel'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'release'}
-          - {os: ubuntu-latest,   nosuggests: true,  r: 'release'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'oldrel-1'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'oldrel-2'}
-
-    env:
-      _R_CHECK_DEPENDS_ONLY_: ${{ matrix.config.nosuggests }}
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          Ncpus: 2
-          r-version: ${{ matrix.config.r }}
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::rcmdcheck
-
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
+    uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main
+    with:
+      ## Legs beyond the org default 8. These still work and are
+      ## deliberate back-compat coverage, so they are preserved.
+      extra-config: |
+        [{"config": {"os": "ubuntu-latest", "nosuggests": false, "r": "oldrel-2"}}, {"config": {"os": "windows-latest", "nosuggests": false, "r": "oldrel-2"}}]


### PR DESCRIPTION
Replaces this repo's hand-rolled matrix with a thin caller on `PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main`.

**63 → 25 lines.**

## Why

Third-party action versions, system dependencies, caching and the check itself were maintained separately in 17 repos. This repo was on `actions/checkout@v4`; the org spread was v2/v4/v5/v6/v7. Node 20 deprecation warnings are the current symptom. Consolidated, bumping it once in `actions` updates every repo.

## Customizations preserved

`oldrel-2` on Ubuntu and Windows via `extra-config` — still-working back-compat coverage.

## Dropped deliberately

Nothing.

**Depends on** PredictiveEcology/actions#27 (per-leg `extra-env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DVjmY3im9Xak7tXLSMGCa