### PR TITLE
ci: bring the reusable workflow to development; pin exact R versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,62 +1,24 @@
-on:
-  push:
-    branches:
-      - main
-      - master
-      - development
-      - LandWeb
-  pull_request:
-    branches:
-      - main
-      - master
-      - development
+## Thin caller -- the matrix, system dependencies, caching, Drive staging
+## and the check itself all live in PredictiveEcology/actions. This file only
+## says which package to check and what it needs on top of the org defaults.
+##
+## Pinned @main deliberately: tags freeze and rot (v0.1/v0.2 kept the
+## ubuntugis PPA for months after the workflows rejected it). The actions repo
+## gates merges with its own self-test CI.
 
 name: R-CMD-check
 
+on:
+  push:
+    branches: [main, master, development, LandWeb]
+  pull_request:
+    branches: [main, master, development, LandWeb]
+
 jobs:
   R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }}, nosuggests ${{ matrix.config.nosuggests }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: macOS-latest,    nosuggests: false, r: 'release'}
-          - {os: windows-latest,  nosuggests: false, r: 'devel'}
-          - {os: windows-latest,  nosuggests: false, r: 'release'}
-          - {os: windows-latest,  nosuggests: false, r: 'oldrel-1'}
-          - {os: windows-latest,  nosuggests: false, r: 'oldrel-2'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'devel'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'release'}
-          - {os: ubuntu-latest,   nosuggests: true,  r: 'release'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'oldrel-1'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'oldrel-2'}
-
-    env:
-      _R_CHECK_DEPENDS_ONLY_: ${{ matrix.config.nosuggests }}
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          Ncpus: 2
-          r-version: ${{ matrix.config.r }}
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::rcmdcheck
-
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
+    uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main
+    with:
+      ## Legs beyond the org default 8. These still work and are
+      ## deliberate back-compat coverage, so they are preserved.
+      extra-config: |
+        [{"config": {"os": "ubuntu-latest", "nosuggests": false, "r": "oldrel-2"}}, {"config": {"os": "windows-latest", "nosuggests": false, "r": "oldrel-2"}}]

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,7 +18,13 @@ jobs:
   R-CMD-check:
     uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main
     with:
-      ## Legs beyond the org default 8. These still work and are
-      ## deliberate back-compat coverage, so they are preserved.
+      ## Legs beyond the org default 8, pinned to exact R versions rather
+      ## than oldrel-N. On ubuntu-latest the oldrel ladder is not monotone --
+      ## oldrel-4 and oldrel-5 both resolve to 4.1.3 and R 4.2 is unreachable
+      ## -- and it shifts every time R releases. 4.3 is this package's
+      ## declared floor (DESCRIPTION: R >= 4.3), so it is the version the
+      ## matrix should actually prove.
       extra-config: |
-        [{"config": {"os": "ubuntu-latest", "nosuggests": false, "r": "oldrel-2"}}, {"config": {"os": "windows-latest", "nosuggests": false, "r": "oldrel-2"}}]
+        [{"config": {"os": "ubuntu-latest", "nosuggests": false, "r": "4.4"}},
+         {"config": {"os": "windows-latest", "nosuggests": false, "r": "4.4"}},
+         {"config": {"os": "ubuntu-latest", "nosuggests": false, "r": "4.3"}}]

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
+      - uses: PredictiveEcology/actions/install-spatial-deps@main
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
`development` never received the reusable-workflow migration — PR #23 was based on and merged into `main`, so the branch every PR actually targets still runs the old self-managed workflow.

Cherry-picks the migration (`f6aa3ef`) rather than merging `main`, because `main` also carries 34 committed `docs/` files that `development` deliberately does not have.

### Three changes

**1. R-CMD-check now calls the org reusable workflow** — the same file that has been on `main` since #23.

**2. The deep matrix legs are pinned to exact R versions instead of `oldrel-N`.** The oldrel ladder is platform-dependent and not monotone. Resolved against the exact platform string `setup-r` sends:

```
ubuntu-latest (noble)      ubuntu-22.04            macOS arm64
oldrel-1 -> 4.5.3          oldrel-1 -> 4.5.3       oldrel-1 -> 4.4.3
oldrel-2 -> 4.4.3          oldrel-2 -> 4.3.3       oldrel-2 -> 4.3.3
oldrel-3 -> 4.3.3          oldrel-3 -> 4.2.3       oldrel-3 -> 4.3.3  dup
oldrel-4 -> 4.1.3  !!      oldrel-4 -> 3.6.3  !!   oldrel-4 -> 4.1.3
oldrel-5 -> 4.1.3  dup     oldrel-5 -> 4.1.3       oldrel-5 -> 4.1.3  dup
```

`r: "4.3"` resolves to 4.3.3 identically on Linux, macOS and Windows, and Posit ships noble `.deb`s down to 4.0.5. 4.3 is this package's declared floor (`DESCRIPTION: R >= 4.3`), which the matrix previously never tested — `oldrel-2` stops at 4.4.

**3. `test-coverage.yaml` repointed from `install-spatial-deps@v0.2` to `@main`.** Every published tag, v0.1 through v0.5, still runs `add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable`. That installs libgdal37 while Posit's noble binaries link libgdal34, and the mismatch only surfaces at lazy-load. Only `@main` dropped it.

### Note

`main` still has the `@v0.2` pin in `test-coverage.yaml`; it catches up at the next release merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)